### PR TITLE
Uber, Lyft injunction

### DIFF
--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -7,5 +7,5 @@
 - locations: massachusetts, usa
 - companies: uber, lyft
 - workers: 2
-- tags: na
+- tags: 
 - author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -1,11 +1,11 @@
 - date: 2019-09-12
 - sources: https://www.law360.com/employment/articles/1255452/uber-lyft-drivers-fail-to-win-employee-status-via-injunction
-- companies: uber, lyft
 - actions: legal_action
 - struggles: pay_and_benefits, unfair_labor_practices
 - employment_type: contract_workers, gig_workers
 - workers: 2
 - description: Uber drivers filed an injunction to classify workers as employees and to compensate them for overtime pay, paid sick leave and reimbursement for business expenses. On September 17, Lyft drivers filed a similar injunction. Update: New motions have been added to the injunction in March 2020 in light of the coronavirus outbreak. On March 20, 2020, a Massachusetts federal judge ruled that the companies would not be required to classify their drivers as employees.
 - locations: massachusetts, usa
+- companies: uber, lyft
 - tags: na
 - author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -7,5 +7,5 @@
 - locations: massachusetts, usa
 - companies: uber, lyft
 - workers: 2
-- tags: None
+- tags: coronavirus
 - author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -2,7 +2,7 @@
 - sources: https://www.law360.com/employment/articles/1255452/uber-lyft-drivers-fail-to-win-employee-status-via-injunction
 - actions: legal_action
 - struggles: pay_and_benefits, unfair_labor_practices
-- employment_type: contract_workers, gig_workers
+- employment_types: contract_workers, gig_workers
 - description: Uber drivers filed an injunction to classify workers as employees and to compensate them for overtime pay, paid sick leave and reimbursement for business expenses. On September 17, Lyft drivers filed a similar injunction. Update: New motions have been added to the injunction in March 2020 in light of the coronavirus outbreak. On March 20, 2020, a Massachusetts federal judge ruled that the companies would not be required to classify their drivers as employees.
 - locations: massachusetts, usa
 - companies: uber, lyft

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -1,4 +1,4 @@
-- date: 2019-09-12
+- date: 2019/09/12
 - sources: https://www.law360.com/employment/articles/1255452/uber-lyft-drivers-fail-to-win-employee-status-via-injunction
 - actions: legal_action
 - struggles: pay_and_benefits, unfair_labor_practices

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -7,5 +7,5 @@
 - workers: 2
 - description: Uber drivers filed an injunction to classify workers as employees and to compensate them for overtime pay, paid sick leave and reimbursement for business expenses. On September 17, Lyft drivers filed a similar injunction. Update: New motions have been added to the injunction in March 2020 in light of the coronavirus outbreak. On March 20, 2020, a Massachusetts federal judge ruled that the companies would not be required to classify their drivers as employees.
 - locations: massachusetts, usa
-- tags: 
+- tags: na
 - author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -7,5 +7,5 @@
 - locations: massachusetts, usa
 - companies: uber, lyft
 - workers: 2
-- tags: 
+- tags: None
 - author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -1,4 +1,4 @@
-- date: 09/12/2019
+- date: 2019-09-12
 - sources: https://www.law360.com/employment/articles/1255452/uber-lyft-drivers-fail-to-win-employee-status-via-injunction
 - companies: uber, lyft
 - actions: legal_action

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -1,0 +1,11 @@
+- date: 09/12/2019
+- sources: https://www.law360.com/employment/articles/1255452/uber-lyft-drivers-fail-to-win-employee-status-via-injunction
+- companies: uber, lyft
+- actions: legal_action
+- struggles: pay_and_benefits, unfair_labor_practices
+- employment_type: contract_workers, gig_workers
+- workers: 2
+- description: Uber drivers filed an injunction to classify workers as employees and to compensate them for overtime pay, paid sick leave and reimbursement for business expenses. On September 17, Lyft drivers filed a similar injunction. Update: New motions have been added to the injunction in March 2020 in light of the coronavirus outbreak. On March 20, 2020, a Massachusetts federal judge ruled that the companies would not be required to classify their drivers as employees.
+- locations: massachusetts, usa
+- tags: 
+- author: nataliyaned

--- a/actions/032020nn.md
+++ b/actions/032020nn.md
@@ -3,9 +3,9 @@
 - actions: legal_action
 - struggles: pay_and_benefits, unfair_labor_practices
 - employment_type: contract_workers, gig_workers
-- workers: 2
 - description: Uber drivers filed an injunction to classify workers as employees and to compensate them for overtime pay, paid sick leave and reimbursement for business expenses. On September 17, Lyft drivers filed a similar injunction. Update: New motions have been added to the injunction in March 2020 in light of the coronavirus outbreak. On March 20, 2020, a Massachusetts federal judge ruled that the companies would not be required to classify their drivers as employees.
 - locations: massachusetts, usa
 - companies: uber, lyft
+- workers: 2
 - tags: na
 - author: nataliyaned


### PR DESCRIPTION
Workers = 2 because there are two different employees represented, one from each company. 